### PR TITLE
Set PWRDWN bit before resetting internal PHY

### DIFF
--- a/XPD_USB/xpd_usb_otg.c
+++ b/XPD_USB/xpd_usb_otg.c
@@ -622,10 +622,9 @@ static void USB_prvPhyInit(USB_HandleType * pxUSB, USB_PHYType ePHY)
     {
         /* Select FS Embedded PHY */
         USB_REG_BIT(pxUSB, GUSBCFG, PHYSEL) = 1;
+        USB_REG_BIT(pxUSB, GCCFG, PWRDWN) = 1;
 
         USB_prvReset(pxUSB);
-
-        pxUSB->Inst->GCCFG.w = USB_OTG_GCCFG_PWRDWN;
     }
 }
 


### PR DESCRIPTION
On my STM32F7, this is required for the reset to complete; leaving the internal
PHY in power-down during reset causes the reset to hang (SRST bit never returns to 0).